### PR TITLE
Custom script to extract metrics and submit them to Sasquatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.DS_STORE

--- a/extract_metrics.py
+++ b/extract_metrics.py
@@ -1,0 +1,99 @@
+import os
+import argparse
+import ijson
+import requests
+import metric_emitter
+
+
+class SasquatchBenchmarkProcessor:
+    def __init__(self):
+        self.benchmarks_file = "benchmarks/output.json"
+        self.sasquatch_rest_proxy_url = os.environ["KAFKA_API_URL"]
+        self.module_metric_pairs = []  # (module_name: string, metric_value: float)
+        self.topic_name = "lsst.lf.tape.bench.test"  # TODO: Change to project name
+
+    def start(self):
+        metric = self.parse_cmd_args()
+        self.collect_metric_values(metric)
+        try:
+            cluster_id = self.get_kafka_cluster_id()
+            self.create_kafka_topic(cluster_id)
+            self.post_results_to_sasquatch()
+        except Exception as e:
+            print(e)
+
+    def parse_cmd_args(self):
+        # Parse benchmark metric to compute
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--metric", help="Which benchmark metric to compute")
+        return parser.parse_args().metric
+
+    def collect_metric_values(self, metric):
+        # Collect metric values for each test
+        with open(self.benchmarks_file, "rb") as input_file:
+            modules = list(
+                filter(
+                    lambda module: metric in module["stats"].keys(),
+                    ijson.items(input_file, "benchmarks.item"),
+                )
+            )
+            self.module_metric_pairs = [
+                (module["name"], float(module["stats"][metric])) for module in modules
+            ]
+        print("Found %d values for metric '%s'" % (len(self.module_metric_pairs), metric))
+
+    def get_kafka_cluster_id(self):
+        # Obtain Kafka cluster id
+        headers = {"content-type": "application/json"}
+        r = requests.get(f"{self.sasquatch_rest_proxy_url}/v3/clusters", headers=headers)
+        cluster_id = r.json()["data"][0]["cluster_id"]
+        print(f"Kafka cluster ID: {cluster_id}")
+        return cluster_id
+
+    def check_if_topic_exists(self):
+        # Check if topic exists
+        return (
+            requests.get(
+                f"{self.sasquatch_rest_proxy_url}/topics/{self.topic_name}",
+                headers={"content-type": "application/vnd.kafka.v2+json"},
+            ).status_code
+            == 200
+        )
+
+    def create_kafka_topic(self, cluster_id):
+        # Create Kafka topic
+        if self.check_if_topic_exists():
+            return
+
+        topic_config = {
+            "topic_name": self.topic_name,
+            "partitions_count": 1,
+            "replication_factor": 3,
+        }
+
+        headers = {"content-type": "application/json"}
+
+        response = requests.post(
+            f"{self.sasquatch_rest_proxy_url}/v3/clusters/{cluster_id}/topics",
+            json=topic_config,
+            headers=headers,
+        )
+
+        if response.status_code not in [200, 201]:
+            raise Exception("Could not create Kafka topic!")
+
+    def post_results_to_sasquatch(self):
+        # Post data to Sasquatch
+        for module_name, metric_val in self.module_metric_pairs:
+            emitter = metric_emitter.Emitter(
+                namespace="lsst.lf",
+                name="tape.bench.test",
+                module=module_name,
+                benchmark_type="runtime",
+                benchmark_unit="s",
+            )
+            emitter.set_value(metric_val)
+            emitter.emit()
+
+
+SasquatchBenchmarkProcessor().start()

--- a/metrics.py
+++ b/metrics.py
@@ -8,7 +8,7 @@ import requests
 class MetricsProcessor:
     """Extracts metrics from the benchmarking JSON files and submits them to Sasquatch"""
 
-    BENCHMARKS_FILEPATH = "output.json"
+    BENCHMARKS_FILEPATH = "benchmarks/output.json"
     SASQUATCH_NAMESPACE = "lsst.lf"
 
     # Passed as environment variables from the GitHub action

--- a/metrics.py
+++ b/metrics.py
@@ -1,24 +1,25 @@
-import os
 import argparse
 import ijson
-import requests
 import metric_emitter
+import os
+import requests
 
 
 class MetricsProcessor:
     """Extracts metrics from the benchmarking JSON files and submits them to Sasquatch"""
 
+    BENCHMARKS_FILEPATH = "output.json"
+    SASQUATCH_NAMESPACE = "lsst.lf"
+
+    # Passed as environment variables from the GitHub action
+    SASQUATCH_REST_PROXY_URL = os.environ["SASQUATCH_REST_PROXY_URL"]
+    BENCH_NAME = f"{os.environ['PROJECT_NAME']}.bench"
+
     def __init__(self):
-        self.benchmarks_filepath = "benchmarks/output.json"
-
-        # These are passed as environment variables from the GitHub action
-        self.sasquatch_rest_proxy_url = os.environ["KAFKA_API_URL"]
-        self.sasquatch_namespace = "lsst.lf"
-
-        self.project_name = os.environ["PROJECT_NAME"]
-        self.topic_name = f"{self.sasquatch_namespace}.{self.project_name}"
-
-        self.module_metric_pairs = []  # (module_name: string, metric_value: float)
+        # Name of the Kafka topic to send the metrics to
+        self.topic_name = f"{self.SASQUATCH_NAMESPACE}.{self.BENCH_NAME}"
+        # Dictionary of metric values by module
+        self.module_metrics = {}  # { module_name: metric_value, ... }
 
     def start(self):
         metric = self.parse_cmdline_args()
@@ -49,35 +50,31 @@ class MetricsProcessor:
         metric : str, required
             This is the name of the metric to extract.
         """
-        with open(self.benchmarks_filepath, "rb") as input_file:
+        with open(self.BENCHMARKS_FILEPATH, "rb") as input_file:
+            # Filter out modules missing the computed metric
             modules = list(
                 filter(
                     lambda module: metric in module["stats"].keys(),
                     ijson.items(input_file, "benchmarks.item"),
                 )
             )
-            self.module_metric_pairs = [
-                (module["name"], float(module["stats"][metric])) for module in modules
-            ]
-        print(f"Found {len(self.module_metric_pairs)} values for metric {metric}")
+            # Create dictionary with the modules and respective metric
+            self.module_metrics = {module["name"]: float(module["stats"][metric]) for module in modules}
+            print(f"Found {len(self.module_metrics)} values for metric '{metric}'")
 
     def get_kafka_cluster_id(self):
         """Performs request to the Sasquatch REST API to obtain the Kafka Cluster ID."""
         headers = {"content-type": "application/json"}
-        r = requests.get(f"{self.sasquatch_rest_proxy_url}/v3/clusters", headers=headers)
+        r = requests.get(f"{self.SASQUATCH_REST_PROXY_URL}/v3/clusters", headers=headers)
         cluster_id = r.json()["data"][0]["cluster_id"]
         print(f"Kafka cluster ID: {cluster_id}")
         return cluster_id
 
     def check_if_kafka_topic_exists(self):
         """Performs request to the Sasquatch REST API to check if the Kafka topic for the current project exists."""
-        return (
-            requests.get(
-                f"{self.sasquatch_rest_proxy_url}/topics/{self.topic_name}",
-                headers={"content-type": "application/vnd.kafka.v2+json"},
-            ).status_code
-            == 200
-        )
+        headers = {"content-type": "application/vnd.kafka.v2+json"}
+        response = requests.get(f"{self.SASQUATCH_REST_PROXY_URL}/topics/{self.topic_name}", headers=headers)
+        return response.status_code == 200
 
     def create_kafka_topic(self, cluster_id):
         """Creates a Kafka topic if it does not yet exist for the current project.
@@ -101,20 +98,22 @@ class MetricsProcessor:
         headers = {"content-type": "application/json"}
 
         response = requests.post(
-            f"{self.sasquatch_rest_proxy_url}/v3/clusters/{cluster_id}/topics",
+            f"{self.SASQUATCH_REST_PROXY_URL}/v3/clusters/{cluster_id}/topics",
             json=topic_config,
             headers=headers,
         )
 
         if response.status_code not in [200, 201]:
-            raise Exception("Could not create Kafka topic!")
+            raise Exception("Could not create topic!")
+        else:
+            print(f"Topic '{self.topic_name}' created successfully!")
 
     def submit_results_to_sasquatch(self):
         """Posts metrics to Sasquatch using the metric-emitter package."""
-        for module_name, metric_val in self.module_metric_pairs:
+        for module_name, metric_val in self.module_metrics.items():
             emitter = metric_emitter.Emitter(
-                namespace=self.sasquatch_namespace,
-                name=f"{self.project_name}.bench.test",
+                namespace=self.SASQUATCH_NAMESPACE,
+                name=self.BENCH_NAME,
                 module=module_name,
                 benchmark_type="runtime",
                 benchmark_unit="s",

--- a/metrics.py
+++ b/metrics.py
@@ -9,7 +9,7 @@ class MetricsProcessor:
     """Extracts metrics from the benchmarking JSON files and submits them to Sasquatch"""
 
     def __init__(self):
-        self.benchmarks_filepath = "../benchmarks/output.json"
+        self.benchmarks_filepath = "benchmarks/output.json"
 
         # These are passed as environment variables from the GitHub action
         self.sasquatch_rest_proxy_url = os.environ["KAFKA_API_URL"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ijson==3.2.2
+lf-metric-emitter==0.0.3
+requests==2.31.0


### PR DESCRIPTION
Creates a Python script that:

- Extracts a relevant metric from the computed benchmarks of a project (e.g. min, max runtime)
- Submits those metrics to Sasquatch using [metric-emitter](https://github.com/lincc-frameworks/metric-emitter/tree/main)